### PR TITLE
feat: add graduated gauge panel

### DIFF
--- a/packages/studio-base/src/i18n/en/panels.ts
+++ b/packages/studio-base/src/i18n/en/panels.ts
@@ -11,6 +11,8 @@ export const panels = {
   dataSourceInfoDescription: "View details like topics and timestamps for the current data source.",
   gauge: "Gauge",
   gaugeDescription: "Display a colored gauge based on a continuous value.",
+  graduatedGauge: "Graduated Gauge",
+  graduatedGaugeDescription: "Display a colored gauge with tick marks.",
   image: "Image",
   imageDescription: "Display annotated images.",
   indicator: "Indicator",

--- a/packages/studio-base/src/i18n/ja/panels.ts
+++ b/packages/studio-base/src/i18n/ja/panels.ts
@@ -14,6 +14,8 @@ export const panels: Partial<TypeOptions["resources"]["panels"]> = {
     "現在のデータソースに関するトピックやタイムスタンプなどの詳細を表示します。",
   gauge: "ゲージ",
   gaugeDescription: "連続値に基づく色付きのゲージを表示します。",
+  graduatedGauge: "目盛り付きゲージ",
+  graduatedGaugeDescription: "目盛り付きの連続値ゲージを表示します。",
   image: "画像",
   imageDescription: "注釈付きの画像を表示します。",
   indicator: "インジケーター",

--- a/packages/studio-base/src/i18n/zh/panels.ts
+++ b/packages/studio-base/src/i18n/zh/panels.ts
@@ -13,6 +13,8 @@ export const panels: Partial<TypeOptions["resources"]["panels"]> = {
   dataSourceInfoDescription: "查看当前数据源的主题和时间戳等详细信息。",
   gauge: "仪表",
   gaugeDescription: "基于连续值显示彩色仪表。",
+  graduatedGauge: "刻度仪表",
+  graduatedGaugeDescription: "显示带刻度的彩色仪表。",
   image: "图像",
   imageDescription: "显示带注释的图像。",
   indicator: "指示器",

--- a/packages/studio-base/src/panels/GraduatedGauge/GraduatedGauge.tsx
+++ b/packages/studio-base/src/panels/GraduatedGauge/GraduatedGauge.tsx
@@ -1,0 +1,390 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import * as _ from "lodash-es";
+import { useCallback, useEffect, useLayoutEffect, useReducer, useState } from "react";
+import { v4 as uuidv4 } from "uuid";
+
+import { parseMessagePath, MessagePath } from "@foxglove/message-path";
+import { MessageEvent, PanelExtensionContext, SettingsTreeAction } from "@foxglove/studio";
+import { simpleGetMessagePathDataItems } from "@foxglove/studio-base/components/MessagePathSyntax/simpleGetMessagePathDataItems";
+import { turboColorString } from "@foxglove/studio-base/util/colorUtils";
+
+import { settingsActionReducer, useSettingsTree } from "./settings";
+import type { Config } from "./types";
+
+type Props = {
+  context: PanelExtensionContext;
+};
+
+const defaultConfig: Config = {
+  path: "",
+  minValue: 0,
+  maxValue: 1,
+  colorMap: "red-yellow-green",
+  colorMode: "colormap",
+  gradient: ["#0000ff", "#ff00ff"],
+  reverse: false,
+};
+
+type State = {
+  path: string;
+  parsedPath: MessagePath | undefined;
+  latestMessage: MessageEvent | undefined;
+  latestMatchingQueriedData: unknown;
+  error: Error | undefined;
+  pathParseError: string | undefined;
+};
+
+type Action =
+  | { type: "frame"; messages: readonly MessageEvent[] }
+  | { type: "path"; path: string }
+  | { type: "seek" };
+
+function getSingleDataItem(results: unknown[]) {
+  if (results.length <= 1) {
+    return results[0];
+  }
+  throw new Error("Message path produced multiple results");
+}
+
+function reducer(state: State, action: Action): State {
+  try {
+    switch (action.type) {
+      case "frame": {
+        if (state.pathParseError != undefined) {
+          return { ...state, latestMessage: _.last(action.messages), error: undefined };
+        }
+        let latestMatchingQueriedData = state.latestMatchingQueriedData;
+        let latestMessage = state.latestMessage;
+        if (state.parsedPath) {
+          for (const message of action.messages) {
+            if (message.topic !== state.parsedPath.topicName) {
+              continue;
+            }
+            const data = getSingleDataItem(
+              simpleGetMessagePathDataItems(message, state.parsedPath),
+            );
+            if (data != undefined) {
+              latestMatchingQueriedData = data;
+              latestMessage = message;
+            }
+          }
+        }
+        return { ...state, latestMessage, latestMatchingQueriedData, error: undefined };
+      }
+      case "path": {
+        const newPath = parseMessagePath(action.path);
+        let pathParseError: string | undefined;
+        if (
+          newPath?.messagePath.some(
+            (part) =>
+              (part.type === "filter" && typeof part.value === "object") ||
+              (part.type === "slice" &&
+                (typeof part.start === "object" || typeof part.end === "object")),
+          ) === true
+        ) {
+          pathParseError = "Message paths using variables are not currently supported";
+        }
+        let latestMatchingQueriedData: unknown;
+        let error: Error | undefined;
+        try {
+          latestMatchingQueriedData =
+            newPath && pathParseError == undefined && state.latestMessage
+              ? getSingleDataItem(simpleGetMessagePathDataItems(state.latestMessage, newPath))
+              : undefined;
+        } catch (err) {
+          error = err;
+        }
+        return {
+          ...state,
+          path: action.path,
+          parsedPath: newPath,
+          latestMatchingQueriedData,
+          error,
+          pathParseError,
+        };
+      }
+      case "seek":
+        return {
+          ...state,
+          latestMessage: undefined,
+          latestMatchingQueriedData: undefined,
+          error: undefined,
+        };
+    }
+  } catch (error) {
+    return { ...state, latestMatchingQueriedData: undefined, error };
+  }
+}
+
+function getConicGradient(config: Config, width: number, height: number, gaugeAngle: number) {
+  let colorStops: { color: string; location: number }[];
+  switch (config.colorMode) {
+    case "colormap":
+      switch (config.colorMap) {
+        case "red-yellow-green":
+          colorStops = [
+            { color: "#f00", location: 0 },
+            { color: "#ff0", location: 0.5 },
+            { color: "#0c0", location: 1 },
+          ];
+          break;
+        case "rainbow":
+          colorStops = [
+            { color: "#f0f", location: 0 },
+            { color: "#00f", location: 1 / 5 },
+            { color: "#0ff", location: 2 / 5 },
+            { color: "#0f0", location: 3 / 5 },
+            { color: "#ff0", location: 4 / 5 },
+            { color: "#f00", location: 5 / 5 },
+          ];
+          break;
+        case "turbo": {
+          const numStops = 20;
+          colorStops = new Array(numStops).fill(undefined).map((_x, i) => ({
+            color: turboColorString(i / (numStops - 1)),
+            location: i / (numStops - 1),
+          }));
+          break;
+        }
+      }
+      break;
+    case "gradient":
+      colorStops = [
+        { color: config.gradient[0], location: 0 },
+        { color: config.gradient[1], location: 1 },
+      ];
+      break;
+  }
+  if (config.reverse) {
+    colorStops = colorStops
+      .map((stop) => ({ color: stop.color, location: 1 - stop.location }))
+      .reverse();
+  }
+
+  return `conic-gradient(from ${-Math.PI / 2 + gaugeAngle}rad at 50% ${
+    100 * (width / 2 / height)
+  }%, ${colorStops
+    .map((stop) => `${stop.color} ${stop.location * 2 * (Math.PI / 2 - gaugeAngle)}rad`)
+    .join(",")}, ${colorStops[0]!.color})`;
+}
+
+export function GraduatedGauge({ context }: Props): JSX.Element {
+  // panel extensions must notify when they've completed rendering
+  // onRender will setRenderDone to a done callback which we can invoke after we've rendered
+  const [renderDone, setRenderDone] = useState<() => void>(() => () => {});
+
+  const [config, setConfig] = useState(() => ({
+    ...defaultConfig,
+    ...(context.initialState as Partial<Config>),
+  }));
+
+  const [state, dispatch] = useReducer(
+    reducer,
+    config,
+    ({ path }): State => ({
+      path,
+      parsedPath: parseMessagePath(path),
+      latestMessage: undefined,
+      latestMatchingQueriedData: undefined,
+      pathParseError: undefined,
+      error: undefined,
+    }),
+  );
+
+  useLayoutEffect(() => {
+    dispatch({ type: "path", path: config.path });
+  }, [config.path]);
+
+  useEffect(() => {
+    context.saveState(config);
+    context.setDefaultPanelTitle(config.path === "" ? undefined : config.path);
+  }, [config, context]);
+
+  useEffect(() => {
+    context.onRender = (renderState, done) => {
+      setRenderDone(() => done);
+
+      if (renderState.didSeek === true) {
+        dispatch({ type: "seek" });
+      }
+
+      if (renderState.currentFrame) {
+        dispatch({ type: "frame", messages: renderState.currentFrame });
+      }
+    };
+    context.watch("currentFrame");
+    context.watch("didSeek");
+
+    return () => {
+      context.onRender = undefined;
+    };
+  }, [context]);
+
+  const settingsActionHandler = useCallback(
+    (action: SettingsTreeAction) => {
+      setConfig((prevConfig) => settingsActionReducer(prevConfig, action));
+    },
+    [setConfig],
+  );
+
+  const settingsTree = useSettingsTree(config, state.pathParseError, state.error?.message);
+  useEffect(() => {
+    context.updatePanelSettingsEditor({
+      actionHandler: settingsActionHandler,
+      nodes: settingsTree,
+    });
+  }, [context, settingsActionHandler, settingsTree]);
+
+  useEffect(() => {
+    if (state.parsedPath?.topicName != undefined) {
+      context.subscribe([{ topic: state.parsedPath.topicName, preload: false }]);
+    }
+    return () => {
+      context.unsubscribeAll();
+    };
+  }, [context, state.parsedPath?.topicName]);
+
+  // Indicate render is complete - the effect runs after the dom is updated
+  useEffect(() => {
+    renderDone();
+  }, [renderDone]);
+
+  const rawValue =
+    typeof state.latestMatchingQueriedData === "number" ||
+    typeof state.latestMatchingQueriedData === "string"
+      ? Number(state.latestMatchingQueriedData)
+      : NaN;
+
+  const { minValue, maxValue } = config;
+  const scaledValue =
+    (Math.max(minValue, Math.min(rawValue, maxValue)) - minValue) / (maxValue - minValue);
+  const outOfBounds = rawValue < minValue || rawValue > maxValue;
+
+  const padding = 0.1;
+  const centerX = 0.5 + padding;
+  const centerY = 0.5 + padding;
+  const gaugeAngle = -Math.PI / 8;
+  const radius = 0.5;
+  const innerRadius = 0.4;
+  const width = 1 + 2 * padding;
+  const height =
+    Math.max(
+      centerY - radius * Math.sin(gaugeAngle),
+      centerY - innerRadius * Math.sin(gaugeAngle),
+    ) + padding;
+  const needleThickness = 8;
+  const needleExtraLength = 0.05;
+  const numTicks = 10;
+  const ticks = new Array(numTicks + 1).fill(undefined).map((_x, i) => {
+    const angle = -Math.PI / 2 + gaugeAngle + (i / numTicks) * 2 * (Math.PI / 2 - gaugeAngle);
+    return {
+      x1: centerX + innerRadius * Math.cos(angle),
+      y1: centerY - innerRadius * Math.sin(angle),
+      x2: centerX + radius * Math.cos(angle),
+      y2: centerY - radius * Math.sin(angle),
+    };
+  });
+  const [clipPathId] = useState(() => `gauge-clip-path-${uuidv4()}`);
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-around",
+        alignItems: "center",
+        overflow: "hidden",
+        padding: 8,
+      }}
+    >
+      <div style={{ width: "100%", overflow: "hidden" }}>
+        <div
+          style={{
+            position: "relative",
+            maxWidth: "100%",
+            maxHeight: "100%",
+            aspectRatio: `${width} / ${height}`,
+            margin: "0 auto",
+            transform: "scale(1)", // Work around a Safari bug: https://bugs.webkit.org/show_bug.cgi?id=231849
+          }}
+        >
+          <div
+            style={{
+              width: "100%",
+              height: "100%",
+              background: getConicGradient(config, width, height, gaugeAngle),
+              clipPath: `url(#${clipPathId})`,
+              opacity: state.latestMatchingQueriedData == undefined ? 0.5 : 1,
+            }}
+          />
+          <svg
+            viewBox={`0 0 ${width} ${height}`}
+            style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%" }}
+          >
+            {ticks.map((tick, i) => (
+              <line
+                // eslint-disable-next-line react/no-array-index-key
+                key={i}
+                x1={tick.x1}
+                y1={tick.y1}
+                x2={tick.x2}
+                y2={tick.y2}
+                stroke="black"
+                strokeWidth={0.01}
+              />
+            ))}
+          </svg>
+          <div
+            style={{
+              backgroundColor: outOfBounds ? "orange" : "white",
+              width: needleThickness,
+              height: `${(100 * (radius + needleExtraLength)) / height}%`,
+              border: "2px solid black",
+              borderRadius: needleThickness / 2,
+              position: "absolute",
+              bottom: `${100 * (1 - centerY / height)}%`,
+              left: "50%",
+              transformOrigin: "bottom left",
+              margin: "0 auto",
+              transform: [
+                `scaleZ(1)`,
+                `rotate(${
+                  -Math.PI / 2 + gaugeAngle + scaledValue * 2 * (Math.PI / 2 - gaugeAngle)
+                }rad)`,
+                `translateX(${-needleThickness / 2}px)`,
+                `translateY(${needleThickness / 2}px)`,
+              ].join(" "),
+              display: Number.isFinite(scaledValue) ? "block" : "none",
+            }}
+          />
+        </div>
+        <svg style={{ position: "absolute" }}>
+          <clipPath id={clipPathId} clipPathUnits="objectBoundingBox">
+            <path
+              transform={`scale(${1 / width}, ${1 / height})`}
+              d={[
+                `M ${centerX - radius * Math.cos(gaugeAngle)},${
+                  centerY - radius * Math.sin(gaugeAngle)
+                }`,
+                `A 0.5,0.5 0 ${gaugeAngle < 0 ? 1 : 0} 1 ${
+                  centerX + radius * Math.cos(gaugeAngle)
+                },${centerY - radius * Math.sin(gaugeAngle)}`,
+                `L ${centerX + innerRadius * Math.cos(gaugeAngle)},${
+                  centerY - innerRadius * Math.sin(gaugeAngle)
+                }`,
+                `A ${innerRadius},${innerRadius} 0 ${gaugeAngle < 0 ? 1 : 0} 0 ${
+                  centerX - innerRadius * Math.cos(gaugeAngle)
+                },${centerY - innerRadius * Math.sin(gaugeAngle)}`,
+                `Z`,
+              ].join(" ")}
+            />
+          </clipPath>
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/packages/studio-base/src/panels/GraduatedGauge/index.tsx
+++ b/packages/studio-base/src/panels/GraduatedGauge/index.tsx
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { StrictMode, useMemo } from "react";
+import ReactDOM from "react-dom";
+
+import { useCrash } from "@foxglove/hooks";
+import { PanelExtensionContext } from "@foxglove/studio";
+import { CaptureErrorBoundary } from "@foxglove/studio-base/components/CaptureErrorBoundary";
+import Panel from "@foxglove/studio-base/components/Panel";
+import { PanelExtensionAdapter } from "@foxglove/studio-base/components/PanelExtensionAdapter";
+import ThemeProvider from "@foxglove/studio-base/theme/ThemeProvider";
+import { SaveConfig } from "@foxglove/studio-base/types/panels";
+
+import { GraduatedGauge } from "./GraduatedGauge";
+import { Config } from "./types";
+
+function initPanel(crash: ReturnType<typeof useCrash>, context: PanelExtensionContext) {
+  // eslint-disable-next-line react/no-deprecated
+  ReactDOM.render(
+    <StrictMode>
+      <CaptureErrorBoundary onError={crash}>
+        <ThemeProvider isDark>
+          <GraduatedGauge context={context} />
+        </ThemeProvider>
+      </CaptureErrorBoundary>
+    </StrictMode>,
+    context.panelElement,
+  );
+  return () => {
+    // eslint-disable-next-line react/no-deprecated
+    ReactDOM.unmountComponentAtNode(context.panelElement);
+  };
+}
+
+type Props = {
+  config: Config;
+  saveConfig: SaveConfig<Config>;
+};
+
+function GraduatedGaugePanelAdapter(props: Props) {
+  const crash = useCrash();
+  const boundInitPanel = useMemo(() => initPanel.bind(undefined, crash), [crash]);
+
+  return (
+    <PanelExtensionAdapter
+      config={props.config}
+      saveConfig={props.saveConfig}
+      initPanel={boundInitPanel}
+      highestSupportedConfigVersion={1}
+    />
+  );
+}
+
+GraduatedGaugePanelAdapter.panelType = "GraduatedGauge";
+GraduatedGaugePanelAdapter.defaultConfig = {};
+
+export default Panel(GraduatedGaugePanelAdapter);

--- a/packages/studio-base/src/panels/GraduatedGauge/settings.ts
+++ b/packages/studio-base/src/panels/GraduatedGauge/settings.ts
@@ -1,0 +1,110 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import { produce } from "immer";
+import * as _ from "lodash-es";
+import { useMemo } from "react";
+
+import { useShallowMemo } from "@foxglove/hooks";
+import { SettingsTreeAction, SettingsTreeNode, SettingsTreeNodes } from "@foxglove/studio";
+
+import type { Config } from "./types";
+
+export function settingsActionReducer(prevConfig: Config, action: SettingsTreeAction): Config {
+  return produce(prevConfig, (draft) => {
+    switch (action.action) {
+      case "perform-node-action":
+        throw new Error(`Unhandled node action: ${action.payload.id}`);
+      case "update":
+        switch (action.payload.path[0]) {
+          case "general":
+            _.set(draft, [action.payload.path[1]!], action.payload.value);
+            break;
+          default:
+            throw new Error(`Unexpected payload.path[0]: ${action.payload.path[0]}`);
+        }
+        break;
+    }
+  });
+}
+
+const supportedDataTypes = [
+  "int8",
+  "uint8",
+  "int16",
+  "uint16",
+  "int32",
+  "uint32",
+  "float32",
+  "float64",
+  "string",
+];
+
+export function useSettingsTree(
+  config: Config,
+  pathParseError: string | undefined,
+  error: string | undefined,
+): SettingsTreeNodes {
+  const generalSettings = useMemo(
+    (): SettingsTreeNode => ({
+      error,
+      fields: {
+        path: {
+          label: "Message path",
+          input: "messagepath",
+          value: config.path,
+          error: pathParseError,
+          validTypes: supportedDataTypes,
+        },
+        minValue: {
+          label: "Min",
+          input: "number",
+          value: config.minValue,
+        },
+        maxValue: {
+          label: "Max",
+          input: "number",
+          value: config.maxValue,
+        },
+        colorMode: {
+          label: "Color mode",
+          input: "select",
+          value: config.colorMode,
+          options: [
+            { label: "Color map", value: "colormap" },
+            { label: "Gradient", value: "gradient" },
+          ],
+        },
+        ...(config.colorMode === "colormap" && {
+          colorMap: {
+            label: "Color map",
+            input: "select",
+            value: config.colorMap,
+            options: [
+              { label: "Red to green", value: "red-yellow-green" },
+              { label: "Rainbow", value: "rainbow" },
+              { label: "Turbo", value: "turbo" },
+            ],
+          },
+        }),
+        ...(config.colorMode === "gradient" && {
+          gradient: {
+            label: "Gradient",
+            input: "gradient",
+            value: config.gradient,
+          },
+        }),
+        reverse: {
+          label: "Reverse",
+          input: "boolean",
+          value: config.reverse,
+        },
+      },
+    }),
+    [error, config, pathParseError],
+  );
+  return useShallowMemo({
+    general: generalSettings,
+  });
+}

--- a/packages/studio-base/src/panels/GraduatedGauge/thumbnail.png
+++ b/packages/studio-base/src/panels/GraduatedGauge/thumbnail.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac8e6ac602612d9bf3237bed9b587223adc94b8f674c4f8e754621e0759cb4fb
+size 9163

--- a/packages/studio-base/src/panels/GraduatedGauge/types.ts
+++ b/packages/studio-base/src/panels/GraduatedGauge/types.ts
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+export type Config = {
+  path: string;
+  minValue: number;
+  maxValue: number;
+  colorMode: "colormap" | "gradient";
+  colorMap: "red-yellow-green" | "rainbow" | "turbo";
+  gradient: [string, string];
+  reverse: boolean;
+};

--- a/packages/studio-base/src/panels/index.ts
+++ b/packages/studio-base/src/panels/index.ts
@@ -8,6 +8,7 @@ import { TAB_PANEL_TYPE } from "@foxglove/studio-base/util/globalConstants";
 
 import dataSourceInfoThumbnail from "./DataSourceInfo/thumbnail.png";
 import gaugeThumbnail from "./Gauge/thumbnail.png";
+import graduatedGaugeThumbnail from "./GraduatedGauge/thumbnail.png";
 import imageThumbnail from "./Image/thumbnail.png";
 import indicatorThumbnail from "./Indicator/thumbnail.png";
 import logThumbnail from "./Log/thumbnail.png";
@@ -70,6 +71,13 @@ export const getBuiltin: (t: TFunction<"panels">) => PanelInfo[] = (t) => [
     description: t("gaugeDescription"),
     thumbnail: gaugeThumbnail,
     module: async () => await import("./Gauge"),
+  },
+  {
+    title: t("graduatedGauge"),
+    type: "GraduatedGauge",
+    description: t("graduatedGaugeDescription"),
+    thumbnail: graduatedGaugeThumbnail,
+    module: async () => await import("./GraduatedGauge"),
   },
   {
     title: t("teleop"),


### PR DESCRIPTION
## Summary
- add GraduatedGauge panel with tick marks rendered along the gauge
- expose new panel in catalog and translations

## Testing
- `yarn lint packages/studio-base/src/panels/GraduatedGauge/GraduatedGauge.tsx packages/studio-base/src/panels/GraduatedGauge/settings.ts packages/studio-base/src/panels/GraduatedGauge/types.ts packages/studio-base/src/panels/index.ts packages/studio-base/src/i18n/en/panels.ts packages/studio-base/src/i18n/ja/panels.ts packages/studio-base/src/i18n/zh/panels.ts` *(fails: SyntaxError: Unexpected identifier 'https')*
- `git lfs pull` *(fails: missing protocol)*
- `yarn test packages/studio-base/src/panels/GraduatedGauge/GraduatedGauge.tsx packages/studio-base/src/panels/index.ts packages/studio-base/src/i18n/en/panels.ts packages/studio-base/src/i18n/ja/panels.ts packages/studio-base/src/i18n/zh/panels.ts` *(fails: SyntaxError: Unexpected identifier 'https')*


------
https://chatgpt.com/codex/tasks/task_e_68a338a1b98c83329ce4a6a5230c5dde