### PR TITLE
feat: add configurable graduations to gauge panel

### DIFF
--- a/packages/studio-base/src/panels/GraduatedGauge/GraduatedGauge.tsx
+++ b/packages/studio-base/src/panels/GraduatedGauge/GraduatedGauge.tsx
@@ -26,6 +26,8 @@ const defaultConfig: Config = {
   colorMode: "colormap",
   gradient: ["#0000ff", "#ff00ff"],
   reverse: false,
+  showGraduations: true,
+  graduationScale: 10,
 };
 
 type State = {
@@ -277,16 +279,24 @@ export function GraduatedGauge({ context }: Props): JSX.Element {
     ) + padding;
   const needleThickness = 8;
   const needleExtraLength = 0.05;
-  const numTicks = 10;
-  const ticks = new Array(numTicks + 1).fill(undefined).map((_x, i) => {
-    const angle = -Math.PI / 2 + gaugeAngle + (i / numTicks) * 2 * (Math.PI / 2 - gaugeAngle);
-    return {
-      x1: centerX + innerRadius * Math.cos(angle),
-      y1: centerY - innerRadius * Math.sin(angle),
-      x2: centerX + radius * Math.cos(angle),
-      y2: centerY - radius * Math.sin(angle),
-    };
-  });
+  const numTicks = Math.max(1, config.graduationScale);
+  const labelRadius = (innerRadius + radius) / 2;
+  const ticks = config.showGraduations
+    ? new Array(numTicks + 1).fill(undefined).map((_x, i) => {
+        const angle =
+          -Math.PI / 2 + gaugeAngle + (i / numTicks) * 2 * (Math.PI / 2 - gaugeAngle);
+        const value = minValue + (i / numTicks) * (maxValue - minValue);
+        return {
+          x1: centerX + innerRadius * Math.cos(angle),
+          y1: centerY - innerRadius * Math.sin(angle),
+          x2: centerX + radius * Math.cos(angle),
+          y2: centerY - radius * Math.sin(angle),
+          lx: centerX + labelRadius * Math.cos(angle),
+          ly: centerY - labelRadius * Math.sin(angle),
+          value,
+        };
+      })
+    : [];
   const [clipPathId] = useState(() => `gauge-clip-path-${uuidv4()}`);
   return (
     <div
@@ -321,23 +331,37 @@ export function GraduatedGauge({ context }: Props): JSX.Element {
               opacity: state.latestMatchingQueriedData == undefined ? 0.5 : 1,
             }}
           />
-          <svg
-            viewBox={`0 0 ${width} ${height}`}
-            style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%" }}
-          >
-            {ticks.map((tick, i) => (
-              <line
-                // eslint-disable-next-line react/no-array-index-key
-                key={i}
-                x1={tick.x1}
-                y1={tick.y1}
-                x2={tick.x2}
-                y2={tick.y2}
-                stroke="black"
-                strokeWidth={0.01}
-              />
-            ))}
-          </svg>
+          {config.showGraduations && (
+            <svg
+              viewBox={`0 0 ${width} ${height}`}
+              style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%" }}
+            >
+              {ticks.map((tick, i) => (
+                <g
+                  // eslint-disable-next-line react/no-array-index-key
+                  key={i}
+                >
+                  <line
+                    x1={tick.x1}
+                    y1={tick.y1}
+                    x2={tick.x2}
+                    y2={tick.y2}
+                    stroke="black"
+                    strokeWidth={0.01}
+                  />
+                  <text
+                    x={tick.lx}
+                    y={tick.ly}
+                    fontSize={0.05}
+                    textAnchor="middle"
+                    dominantBaseline="central"
+                  >
+                    {tick.value.toFixed(2)}
+                  </text>
+                </g>
+              ))}
+            </svg>
+          )}
           <div
             style={{
               backgroundColor: outOfBounds ? "orange" : "white",
@@ -361,6 +385,17 @@ export function GraduatedGauge({ context }: Props): JSX.Element {
               display: Number.isFinite(scaledValue) ? "block" : "none",
             }}
           />
+          <div
+            style={{
+              position: "absolute",
+              top: "50%",
+              left: "50%",
+              transform: "translate(-50%, -50%)",
+              pointerEvents: "none",
+            }}
+          >
+            {Number.isFinite(rawValue) ? rawValue.toFixed(2) : ""}
+          </div>
         </div>
         <svg style={{ position: "absolute" }}>
           <clipPath id={clipPathId} clipPathUnits="objectBoundingBox">

--- a/packages/studio-base/src/panels/GraduatedGauge/settings.ts
+++ b/packages/studio-base/src/panels/GraduatedGauge/settings.ts
@@ -67,6 +67,18 @@ export function useSettingsTree(
           input: "number",
           value: config.maxValue,
         },
+        showGraduations: {
+          label: "Show graduations",
+          input: "boolean",
+          value: config.showGraduations,
+        },
+        ...(config.showGraduations && {
+          graduationScale: {
+            label: "Graduation scale",
+            input: "number",
+            value: config.graduationScale,
+          },
+        }),
         colorMode: {
           label: "Color mode",
           input: "select",

--- a/packages/studio-base/src/panels/GraduatedGauge/types.ts
+++ b/packages/studio-base/src/panels/GraduatedGauge/types.ts
@@ -10,4 +10,6 @@ export type Config = {
   colorMap: "red-yellow-green" | "rainbow" | "turbo";
   gradient: [string, string];
   reverse: boolean;
+  showGraduations: boolean;
+  graduationScale: number;
 };


### PR DESCRIPTION
## Summary
- add `GraduatedGauge` settings to toggle graduations and adjust scale
- draw tick marks with numeric labels and show current value in center

## Testing
- `yarn lint packages/studio-base/src/panels/GraduatedGauge/GraduatedGauge.tsx packages/studio-base/src/panels/GraduatedGauge/settings.ts packages/studio-base/src/panels/GraduatedGauge/types.ts` *(fails: Unexpected identifier 'https')*
- `yarn test packages/studio-base/src/panels/GraduatedGauge` *(fails: Unexpected identifier 'https')*


------
https://chatgpt.com/codex/tasks/task_e_68a435a2ff948332812c580e490c4fc8